### PR TITLE
Fixed bugs in controller for non-existing(models/crud) folders

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,7 @@
+[model]
+folder = models
+filename = demo_model
+
+[crud]
+folder = crud
+filename = demo_crud

--- a/controller/generate_crud.py
+++ b/controller/generate_crud.py
@@ -7,11 +7,8 @@ class CreateScript:
     """
         Create a script
     """
-    def __init__(self, filename, code):
-        folder = 'crud'
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-        self.script_name = f'{folder}/{filename}.py'
+    def __init__(self, filepath, code):  
+        self.filepath = filepath
         self.script_code = code
 
     def create_file(self):
@@ -21,7 +18,7 @@ class CreateScript:
         Returns:
             _type_: _description_
         """        
-        with open(self.script_name, 'w') as file:
+        with open(self.filepath, 'w') as file:
             file.write(self.script_code)
 
         return None
@@ -34,10 +31,10 @@ class GenerateCrud:
         env = Environment(loader=file_loader, autoescape=True)
         self.template = env.get_template('crud.jinja')
 
-    def render_template(self, DDB_tables):
+    def render_template(self, DDB_tables, filepath):
 
         output = self.template.render(tables=DDB_tables)
 
         # print(output)
-        script = CreateScript('demo_crud', output)
+        script = CreateScript(filepath, output)
         script.create_file()

--- a/controller/generate_crud.py
+++ b/controller/generate_crud.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: MIT-0
 
 from jinja2 import Environment, FileSystemLoader
-
+import os
 class CreateScript:
     """
         Create a script
     """
     def __init__(self, filename, code):
-        self.script_name = 'crud/'+filename + '.py'
+        folder = 'crud'
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        self.script_name = f'{folder}/{filename}.py'
         self.script_code = code
 
     def create_file(self):

--- a/controller/generate_model.py
+++ b/controller/generate_model.py
@@ -2,13 +2,17 @@
 # SPDX-License-Identifier: MIT-0
 
 from jinja2 import Environment, FileSystemLoader
-
+import os
 class CreateScript:
     """
         Generates model classes
     """
     def __init__(self, filename, code):
-        self.script_name = 'models/'+filename + '.py'
+        folder = 'models'
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+            
+        self.script_name = f'{folder}/{filename}.py'
         self.script_code = code
 
     def create_file(self):

--- a/controller/generate_model.py
+++ b/controller/generate_model.py
@@ -7,12 +7,8 @@ class CreateScript:
     """
         Generates model classes
     """
-    def __init__(self, filename, code):
-        folder = 'models'
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-            
-        self.script_name = f'{folder}/{filename}.py'
+    def __init__(self, filepath, code):  
+        self.filepath = filepath
         self.script_code = code
 
     def create_file(self):
@@ -22,7 +18,7 @@ class CreateScript:
         Returns:
             _type_: None
         """
-        with open(self.script_name, 'w', encoding='utf-8') as file:
+        with open(self.filepath, 'w', encoding='utf-8') as file:
             file.write(self.script_code)
 
         return None
@@ -38,7 +34,7 @@ class GenerateModel:
         env = Environment(loader=file_loader, autoescape=True)
         self.template = env.get_template('model.jinja')
 
-    def render_template(self, table_attributes):
+    def render_template(self, table_attributes, filepath):
         """
             Renders template
 
@@ -47,5 +43,5 @@ class GenerateModel:
         """
 
         output = self.template.render(table_attributes=table_attributes)
-        script = CreateScript('demo_model', output)
+        script = CreateScript(filepath, output)
         script.create_file()


### PR DESCRIPTION
This pull request addresses an issue where creating a file in a non-existing folder was resulting in errors. 

### Changes Made:

Added logic to check if the target directory exists before creating the file.
If the directory does not exist, the code now creates it.
After ensuring the directory exists, the file creation process proceeds without errors.

### Before

`python main.py --file <input_schema.json>`
`Error: File not found. [Errno 2] No such file or directory: 'models/demo_model.py'`
&
`Error: File not found. [Errno 2] No such file or directory: 'models/demo_model.py'`

### After

`python main.py --file <input_schema.json>`
Files created successfully.
```
Generating Model ....
Model generated.
Generating CRUD ....
```